### PR TITLE
Initial structure of object type 0x06

### DIFF
--- a/static/files/sony_wld.ksy
+++ b/static/files/sony_wld.ksy
@@ -89,6 +89,53 @@ types:
       - id: blue
         type: f4
 
+  sprite_pitch:
+    params:
+      - id: num_frames
+        type: u4
+    seq:
+      - id: pitch_cap
+        type: s4
+      - id: num_headings
+        type: u4
+      - id: headings
+        type: sprite_heading(num_frames)
+        repeat: expr
+        repeat-expr: num_headings
+
+  sprite_heading:
+    params:
+      - id: num_frames
+        type: u4
+    seq:
+      - id: heading_cap
+        type: s4
+      - id: frames
+        type: u4
+        repeat: expr
+        repeat-expr: num_frames
+
+  uv_info:
+    seq:
+      - id: uv_origin_x
+        type: f4
+      - id: uv_origin_y
+        type: f4
+      - id: uv_origin_z
+        type: f4
+      - id: u_axis_x
+        type: f4
+      - id: u_axis_y
+        type: f4
+      - id: u_axis_z
+        type: f4
+      - id: v_axis_x
+        type: f4
+      - id: v_axis_y
+        type: f4
+      - id: v_axis_z
+        type: f4
+
   frame_transform:
     seq:
       - id: rotate_denominator
@@ -150,6 +197,7 @@ types:
             0x3: object_type_03 # FRAME and BMINFO
             0x4: object_type_04 # SIMPLESPRITEDEF
             # 0x5: object_type_05 # merchant 25 I think
+            0x6: object_type_06
             0x8: object_type_08
             0x12: object_type_12 # TRACKDEFINITION
             0x13: object_type_13 # TRACKINSTANCE
@@ -233,6 +281,106 @@ types:
   #   TAG "PIZZA_SPRITE"
   # ENDSIMPLESPRITEINST
   # object_type_05:
+
+  # 2DSPRITEDEF
+  object_type_06:
+    doc: |
+      2DSPRITEDEF
+        2DSPRITETAG I_SWORDSPRITE
+        CENTEROFFSET 0.0 1.0 0.0
+        NUMFRAMES 2
+        SLEEP 100
+        SPRITESIZE 1.0 1.0
+        NUMPITCHES 2
+        PITCH 1
+          PITCHCAP 512
+          NUMHEADINGS 2
+          HEADING 1
+            HEADINGCAP 64
+            FRAME "isword.bmp"  sword11
+            FRAME "isword.bmp"  sword11
+          ENDHEADING 1
+          HEADING 2
+            HEADINGCAP 128
+            FRAME "isword.bmp" sword21
+            FRAME "isword.bmp"  sword11
+          ENDHEADING 2
+        ENDPITCH 1
+        PITCH 2
+          PITCHCAP 256
+          NUMHEADINGS 1
+          HEADING 1
+            HEADINGCAP 64
+            FRAME "isword.bmp"  sword11
+            FRAME "isword.bmp"  sword11
+          ENDHEADING 1
+        ENDPITCH 2
+        // Default instance: render info
+        RENDERMETHOD TEXTURE3
+        // RENDERINFO block is optional
+        RENDERINFO
+          //TWOSIDED
+          PEN 52
+          BRIGHTNESS 1.000
+          SCALEDAMBIENT 1.000
+          UVORIGIN 0.5 0.4 0.3
+          UAXIS 1.0 0.22 0.33 0.44
+          VAXIS 1.0 0.25 0.35 0.45
+        ENDRENDERINFO
+      END2DSPRITEDEF
+    seq:
+      - id: name_reference
+        type: s4
+        doc: The name of this sprite
+      - id: flags
+        type: s4
+      - id: num_frames
+        type: s4
+      - id: num_pitches
+        type: s4
+      - id: sprite_size_x
+        type: f4
+      - id: sprite_size_y
+        type: f4
+      - id: fragment
+        type: s4
+      - id: center_offset_x
+        type: f4
+        if: (flags & 0b1) == 1
+      - id: center_offset_y
+        type: f4
+        if: (flags & 0b1) == 1
+      - id: center_offset_z
+        type: f4
+        if: (flags & 0b1) == 1
+      - id: unkn_params4
+        type: f4
+      - id: sleep
+        type: s4
+        if: (flags & 0b1000) >> 3 == 1
+      - id: pitches
+        type: sprite_pitch(num_frames)
+        repeat: expr
+        repeat-expr: num_pitches
+      - id: render_method
+        type: s4
+      - id: renderinfo_flags
+        type: s4
+      - id: pen
+        type: s4
+        if: (renderinfo_flags & 0b1) == 1
+      - id: brightness
+        type: f4
+        if: (renderinfo_flags & 0b10) >> 1 == 1
+      - id: scaled_ambient
+        type: f4
+        if: (renderinfo_flags & 0b100) >> 2 == 1
+      - id: uv_info
+        type: uv_info
+        if: (renderinfo_flags & 0b10000) >> 4 == 1
+    instances:
+      name:
+        type: string_hash_reference(name_reference)
 
   # Added by 3DSPRITEDEF
   # massive - the whole bsp nodes and everything.

--- a/static/files/sony_wld.ksy
+++ b/static/files/sony_wld.ksy
@@ -288,8 +288,7 @@ types:
         repeat: expr
         repeat-expr: num_pitches
       - id: render_method
-        type: u4
-        enum: render_method
+        type: render_method_attrs
       - id: renderinfo_flags
         type: render_flags
       - id: pen
@@ -304,57 +303,63 @@ types:
       - id: uv_info
         type: uv_info
         if: renderinfo_flags.has_uv_info
-    enums:
-      render_method:
-        0x000: transparent
-        0x003: solidfillzerointensity # also TEXTURE*ZEROINTENSITY
-        0x006: wireframe
-        0x007: solidfill
-        0x00b: solidfillconstant
-        0x013: solidfillambient
-        0x017: solidfillscaledambient
-        0x107: texture1
-        0x207: texture2
-        0x307: texture3
-        0x407: texture4
-        0x507: texture5
-        0x113: texture1ambient
-        0x213: texture2ambient
-        0x313: texture3ambient
-        0x413: texture4ambient
-        0x513: texture5ambient
-        0x10b: texture1constant
-        0x20b: texture2constant
-        0x30b: texture3constant
-        0x40b: texture4constant
-        0x50b: texture5constant
-        0x117: texture1scaledambient
-        0x217: texture2scaledambient
-        0x317: texture3scaledambient
-        0x417: texture4scaledambient
-        0x517: texture5scaledambient
-        0x187: transtexture1
-        0x287: transtexture2
-        0x487: transtexture4
-        0x587: transtexture5
-        0x193: transtexture1ambient
-        0x293: transtexture2ambient
-        0x493: transtexture4ambient
-        0x593: transtexture5ambient
-        0x18b: transtexture1constant
-        0x28b: transtexture2constant
-        0x48b: transtexture4constant
-        0x58b: transtexture5constant
-        0x197: transtexture1scaledambient
-        0x297: transtexture2scaledambient
-        0x497: transtexture4scaledambient
-        0x597: transtexture5scaledambient
-        0x183: transtexture1zerointensity
-        0x283: transtexture2zerointensity
-        0x483: transtexture4zerointensity
-        0x583: transtexture5zerointensity
-
     types:
+      render_method_attrs:
+        seq:
+          - id: draw_style
+            type: b2
+            enum: draw_style
+          - id: lighting
+            type: b3
+            enum: lighting
+          - id: shading
+            type: b2
+            enum: shading
+          - id: texture_style
+            type: b4
+            enum: texture_style
+          - id: unused1
+            doc: These bits cause WLDCOM.EXE to crash when decompiling if set
+            type: b5
+          - id: unused2
+            type: b15
+          - id: user_defined
+            type: b1
+        enums:
+          draw_style:
+            0b00: transparent
+            0b01: unknown
+            0b10: wireframe
+            0b11: solid
+          lighting:
+            0b000: zero_intensity
+            0b001: unknown1
+            0b010: constant
+            0b011: xxxxx
+            0b100: ambient
+            0b101: scaled_ambient
+            0b111: invalid
+          shading:
+            0b00: none1
+            0b01: none2
+            0b10: gouraud1
+            0b11: gouraud2
+          texture_style:
+            0b0001: xxxxxxxx
+            0b0010: texture1
+            0b0011: transtexture1
+            0b0100: texture2
+            0b0101: transtexture2
+            0b0110: texture3
+            0b0111: xxxxxxxx
+            0b1000: texture4
+            0b1001: transtexture4
+            0b1010: texture5
+            0b1011: transtexture5
+            0b1100: unknown1
+            0b1101: unknown2
+            0b1110: unknown3
+            0b1111: xxxxx
       sprite_flags:
         seq:
           - id: has_center_offset

--- a/static/files/sony_wld.ksy
+++ b/static/files/sony_wld.ksy
@@ -286,21 +286,31 @@ types:
     seq:
       - id: name_reference
         type: s4
-        doc: The name of this sprite
+        doc: |
+          The name of this sprite
       - id: flags
         type: sprite_flags
       - id: num_frames
+        doc: |
+          The number of frames present in each heading
         type: u4
       - id: num_pitches
         type: s4
+        doc: |
+          The number of pitches
       - id: sprite_size_x
         type: f4
+        doc: |
+          Scale the sprite by this amount in the x direction?
       - id: sprite_size_y
         type: f4
+        doc: |
+          Scale the sprite by this amount in the y direction?
       - id: sphere_fragment
         type: s4
         doc: |
-          When SPHERE is defined this references a 0x22 fragment
+          When SPHERE or SPHERELIST is defined this references a 0x22 fragment.
+          When POLYHEDRON is defined this references a 0x18 fragment.
       - id: depth_scale
         type: f4
         if: flags.has_depth_scale
@@ -326,7 +336,7 @@ types:
         repeat: expr
         repeat-expr: num_pitches
       - id: render_method
-        type: s4
+        type: render_method
       - id: renderinfo_flags
         type: render_flags
       - id: pen
@@ -434,6 +444,103 @@ types:
             type: u4
             repeat: expr
             repeat-expr: num_frames
+      render_method:
+        doc: |
+          SOLIDFILL                    = 0x007 = 0b_0000_0000_0111
+          SOLIDFILLAMBIENT             = 0x013 = 0b_0000_0001_0011
+          SOLIDFILLCONSTANT            = 0x00b = 0b_0000_0000_1011
+          SOLIDFILLSCALEDAMBIENT       = 0x017 = 0b_0000_0001_0111
+          SOLIDFILLZEROINTENSITY       = 0x003 = 0b_0000_0000_0011
+
+          TEXTURE1                     = 0x107 = 0b_0001_0000_0111
+          TEXTURE2                     = 0x207 = 0b_0010_0000_0111
+          TEXTURE3                     = 0x307 = 0b_0011_0000_0111
+          TEXTURE4                     = 0x407 = 0b_0100_0000_0111
+          TEXTURE5                     = 0x507 = 0b_0101_0000_0111
+
+          TEXTURE1AMBIENT              = 0x113 = 0b_0001_0001_0011
+          TEXTURE2AMBIENT              = 0x213 = 0b_0010_0001_0011
+          TEXTURE3AMBIENT              = 0x313 = 0b_0011_0001_0011
+          TEXTURE4AMBIENT              = 0x413 = 0b_0100_0001_0011
+          TEXTURE5AMBIENT              = 0x513 = 0b_0101_0000_0011
+
+          TEXTURE1CONSTANT             = 0x10b = 0b_0001_0000_1011
+          TEXTURE2CONSTANT             = 0x20b = 0b_0010_0000_1011
+          TEXTURE3CONSTANT             = 0x30b = 0b_0011_0000_1011
+          TEXTURE4CONSTANT             = 0x40b = 0b_0100_0000_1011
+          TEXTURE5CONSTANT             = 0x50b = 0b_0101_0000_1011
+
+          TEXTURE1SCALEDAMBIENT        = 0x117 = 0b_0001_0001_0111
+          TEXTURE2SCALEDAMBIENT        = 0x213 = 0b_0010_0001_0111
+          TEXTURE3SCALEDAMBIENT        = 0x313 = 0b_0011_0001_0111
+          TEXTURE4SCALEDAMBIENT        = 0x413 = 0b_0100_0001_0111
+          TEXTURE5SCALEDAMBIENT        = 0x513 = 0b_0101_0000_0111
+
+          TEXTURE1ZEROINTENSITY        = 0x003 = 0b_0000_0000_0011
+          TEXTURE2ZEROINTENSITY        = 0x003 = 0b_0000_0000_0011
+          TEXTURE3ZEROINTENSITY        = 0x003 = 0b_0000_0000_0011
+          TEXTURE4ZEROINTENSITY        = 0x003 = 0b_0000_0000_0011
+          TEXTURE5ZEROINTENSITY        = 0x003 = 0b_0000_0000_0011
+
+          TRANSTEXTURE1                = 0x187 = 0b_0001_1000_0111
+          TRANSTEXTURE2                = 0x287 = 0b_0010_1000_0111
+          TRANSTEXTURE4                = 0x487 = 0b_0100_1000_0111
+          TRANSTEXTURE5                = 0x587 = 0b_0101_1000_0111
+
+          TRANSTEXTURE1AMBIENT         = 0x193 = 0b_0001_1001_0011
+          TRANSTEXTURE2AMBIENT         = 0x293 = 0b_0010_1001_0011
+          TRANSTEXTURE4AMBIENT         = 0x493 = 0b_0100_1001_0011
+          TRANSTEXTURE5AMBIENT         = 0x593 = 0b_0101_1001_0011
+
+          TRANSTEXTURE1CONSTANT        = 0x18b = 0b_0001_1000_1011
+          TRANSTEXTURE2CONSTANT        = 0x18b = 0b_0010_1000_1011
+          TRANSTEXTURE4CONSTANT        = 0x18b = 0b_0100_1000_1011
+          TRANSTEXTURE5CONSTANT        = 0x18b = 0b_0101_1000_1011
+
+          TRANSTEXTURE1SCALEDAMBIENT   = 0x197 = 0b_0001_1001_0111
+          TRANSTEXTURE2SCALEDAMBIENT   = 0x297 = 0b_0010_1001_0111
+          TRANSTEXTURE4SCALEDAMBIENT   = 0x497 = 0b_0100_1001_0111
+          TRANSTEXTURE5SCALEDAMBIENT   = 0x597 = 0b_0101_1001_0111
+
+          TRANSTEXTURE1ZEROINTENSITY   = 0x183 = 0b_0001_1000_0011
+          TRANSTEXTURE2ZEROINTENSITY   = 0x283 = 0b_0010_1000_0011
+          TRANSTEXTURE4ZEROINTENSITY   = 0x483 = 0b_0100_1000_0011
+          TRANSTEXTURE5ZEROINTENSITY   = 0x583 = 0b_0101_1000_0011
+
+          USERDEFINED %d               =  %d
+        seq:
+          - id: flag00
+            type: b1
+            doc: |
+              Always set for known values
+          - id: flag01
+            type: b1
+            doc: |
+              Always set for known values
+          - id: flag02
+            type: b1
+          - id: constant
+            type: b1
+            doc: |
+              Render with constant color value?
+          - id: ambient
+            type: b1
+            doc: |
+              Render with ambient lighting?
+          - id: flag05
+            type: b1
+          - id: flag06
+            type: b1
+          - id: transparent
+            type: b1
+            doc: |
+              Enable texture transparency?
+          - id: num_tex_coords
+            type: b3
+            doc: |
+              The number of texture coordinates
+          - id: ukn
+            type: b21
       render_flags:
         seq:
           - id: has_pen

--- a/static/files/sony_wld.ksy
+++ b/static/files/sony_wld.ksy
@@ -89,53 +89,6 @@ types:
       - id: blue
         type: f4
 
-  sprite_pitch:
-    params:
-      - id: num_frames
-        type: u4
-    seq:
-      - id: pitch_cap
-        type: s4
-      - id: num_headings
-        type: u4
-      - id: headings
-        type: sprite_heading(num_frames)
-        repeat: expr
-        repeat-expr: num_headings
-
-  sprite_heading:
-    params:
-      - id: num_frames
-        type: u4
-    seq:
-      - id: heading_cap
-        type: s4
-      - id: frames
-        type: u4
-        repeat: expr
-        repeat-expr: num_frames
-
-  uv_info:
-    seq:
-      - id: uv_origin_x
-        type: f4
-      - id: uv_origin_y
-        type: f4
-      - id: uv_origin_z
-        type: f4
-      - id: u_axis_x
-        type: f4
-      - id: u_axis_y
-        type: f4
-      - id: u_axis_z
-        type: f4
-      - id: v_axis_x
-        type: f4
-      - id: v_axis_y
-        type: f4
-      - id: v_axis_z
-        type: f4
-
   frame_transform:
     seq:
       - id: rotate_denominator
@@ -328,36 +281,46 @@ types:
           VAXIS 1.0 0.25 0.35 0.45
         ENDRENDERINFO
       END2DSPRITEDEF
+    meta:
+      bit-endian: le
     seq:
       - id: name_reference
         type: s4
         doc: The name of this sprite
       - id: flags
-        type: s4
+        type: sprite_flags
       - id: num_frames
-        type: s4
+        type: u4
       - id: num_pitches
         type: s4
       - id: sprite_size_x
         type: f4
       - id: sprite_size_y
         type: f4
-      - id: fragment
+      - id: sphere_fragment
         type: s4
+        doc: |
+          When SPHERE is defined this references a 0x22 fragment
+      - id: depth_scale
+        type: f4
+        if: flags.has_depth_scale
       - id: center_offset_x
         type: f4
-        if: (flags & 0b1) == 1
+        if: flags.has_center_offset
       - id: center_offset_y
         type: f4
-        if: (flags & 0b1) == 1
-      - id: center_offset_z
+        if: flags.has_center_offset
         type: f4
-        if: (flags & 0b1) == 1
-      - id: unkn_params4
+        if: flags.has_center_offset
+      - id: bounding_radius
         type: f4
+        if: flags.has_bounding_radius
+      - id: current_frame
+        type: u4
+        if: flags.has_current_frame
       - id: sleep
         type: s4
-        if: (flags & 0b1000) >> 3 == 1
+        if: flags.has_sleep
       - id: pitches
         type: sprite_pitch(num_frames)
         repeat: expr
@@ -365,19 +328,198 @@ types:
       - id: render_method
         type: s4
       - id: renderinfo_flags
-        type: s4
+        type: render_flags
       - id: pen
         type: s4
-        if: (renderinfo_flags & 0b1) == 1
+        if: renderinfo_flags.has_pen
       - id: brightness
         type: f4
-        if: (renderinfo_flags & 0b10) >> 1 == 1
+        if: renderinfo_flags.has_brightness
       - id: scaled_ambient
         type: f4
-        if: (renderinfo_flags & 0b100) >> 2 == 1
+        if: renderinfo_flags.has_scaled_ambient
       - id: uv_info
         type: uv_info
-        if: (renderinfo_flags & 0b10000) >> 4 == 1
+        if: renderinfo_flags.has_uv_info
+    types:
+      sprite_flags:
+        seq:
+          - id: has_center_offset
+            type: b1
+          - id: has_bounding_radius
+            type: b1
+          - id: has_current_frame
+            type: b1
+          - id: has_sleep
+            type: b1
+          - id: flag04
+            type: b1
+          - id: flag05
+            type: b1
+          - id: skip_frames
+            type: b1
+          - id: has_depth_scale
+            type: b1
+          - id: flag08
+            type: b1
+          - id: flag09
+            type: b1
+          - id: flag10
+            type: b1
+          - id: flag11
+            type: b1
+          - id: flag12
+            type: b1
+          - id: flag13
+            type: b1
+          - id: flag14
+            type: b1
+          - id: flag15
+            type: b1
+          - id: flag16
+            type: b1
+          - id: flag17
+            type: b1
+          - id: flag18
+            type: b1
+          - id: flag19
+            type: b1
+          - id: flag20
+            type: b1
+          - id: flag21
+            type: b1
+          - id: flag22
+            type: b1
+          - id: flag23
+            type: b1
+          - id: flag24
+            type: b1
+          - id: flag25
+            type: b1
+          - id: flag26
+            type: b1
+          - id: flag27
+            type: b1
+          - id: flag28
+            type: b1
+          - id: flag29
+            type: b1
+          - id: flag30
+            type: b1
+          - id: flag31
+            type: b1
+      sprite_pitch:
+        params:
+          - id: num_frames
+            type: u4
+        seq:
+          - id: pitch_cap
+            type: s4
+          - id: num_headings
+            type: b31
+          - id: top_or_bottom_view
+            type: b1
+          - id: headings
+            type: sprite_heading(num_frames)
+            repeat: expr
+            repeat-expr: num_headings
+      sprite_heading:
+        params:
+          - id: num_frames
+            type: u4
+        seq:
+          - id: heading_cap
+            type: s4
+          - id: frames
+            type: u4
+            repeat: expr
+            repeat-expr: num_frames
+      render_flags:
+        seq:
+          - id: has_pen
+            type: b1
+          - id: has_brightness
+            type: b1
+          - id: has_scaled_ambient
+            type: b1
+          - id: flag03
+            type: b1
+          - id: has_uv_info
+            type: b1
+          - id: flag05
+            type: b1
+          - id: flag06
+            type: b1
+          - id: flag07
+            type: b1
+          - id: flag08
+            type: b1
+          - id: flag09
+            type: b1
+          - id: flag10
+            type: b1
+          - id: flag11
+            type: b1
+          - id: flag12
+            type: b1
+          - id: flag13
+            type: b1
+          - id: flag14
+            type: b1
+          - id: flag15
+            type: b1
+          - id: flag16
+            type: b1
+          - id: flag17
+            type: b1
+          - id: flag18
+            type: b1
+          - id: flag19
+            type: b1
+          - id: flag20
+            type: b1
+          - id: flag21
+            type: b1
+          - id: flag22
+            type: b1
+          - id: flag23
+            type: b1
+          - id: flag24
+            type: b1
+          - id: flag25
+            type: b1
+          - id: flag26
+            type: b1
+          - id: flag27
+            type: b1
+          - id: flag28
+            type: b1
+          - id: flag29
+            type: b1
+          - id: flag30
+            type: b1
+          - id: flag31
+            type: b1
+      uv_info:
+        seq:
+          - id: uv_origin_x
+            type: f4
+          - id: uv_origin_y
+            type: f4
+          - id: uv_origin_z
+            type: f4
+          - id: u_axis_x
+            type: f4
+          - id: u_axis_y
+            type: f4
+          - id: u_axis_z
+            type: f4
+          - id: v_axis_x
+            type: f4
+          - id: v_axis_y
+            type: f4
+          - id: v_axis_z
+            type: f4
     instances:
       name:
         type: string_hash_reference(name_reference)


### PR DESCRIPTION
I decided to take a look at object type 0x06, or what Windcatcher calls "Two-dimensional Object". It's rarely used in the EQ wlds but it was one of the more poorly understood objects/fragments so I couldn't resist :P. 

The Windcatcher docs say that it's used for "coins and blood spatters" which seems to make sense. I haven't done any testing with the EverQuest client to verify exactly what these fields do but I think there's enough here to form a hypothesis :P.

It seems to me that each `PITCH` likely defines a vertical viewing angle of a sprite. The pitch has a `PITCHCAP` which _probably_ represents some sort of range of vertical viewing angles.

Within each `PITCH` there are a number of `HEADING` blocks which likely correspond to the direction from which the sprite is viewed. Again they have a `HEADINGCAP` which probably defines a range of "headings" this applies to.

Then within each `HEADING` there are a number of `FRAME`s. My bet is if there is a single frame these are static sprites and if there are multiple the sprite is animated.

The `RENDERINFO` and `RENDERMETHOD` statements seem to control things like uv mapping and how lighting will be applied to the sprite.

So overall it looks like this defines an object that's rendered as a sprite which changes textures depending on the direction and angle it's viewed from.

There are still some flags/fields that I don't understand but I think this is a start!